### PR TITLE
handle a JSON parse error differently

### DIFF
--- a/lib/wundergroundnode.js
+++ b/lib/wundergroundnode.js
@@ -84,7 +84,7 @@ var Wunderground = function(apikey) {
         if (!query){
             callback(true, "You must supply a query");
             return;
-        }else if (!_.isString(day)){
+        }else if (!day || !_.isString(day)){
             callback(true,  "You must supply a valid day");
             return;
         }else if (!_.isFunction(callback)){
@@ -96,20 +96,18 @@ var Wunderground = function(apikey) {
 
         // Request the url
         request(url, function (error, response, body) {
+            var json = false;
             if (!error && response.statusCode === 200) {
                 error = false;
                 try {
-                    callback.call(that, error, JSON.parse(body));
+                    json = JSON.parse(body);
                 } catch (err) {
-                    console.log('Exception caught in JSON.parse', body);
-                    throw (err)
-                }                    
-                return;
-            } else if (error) {
-                callback.call(that, error, false);
-                return;
+                    console.error('Exception caught in JSON.parse', body);
+                    error = err;
+                }
             }
-
+            callback.call(that, error, json);
+            return;
         });
     };
 
@@ -137,20 +135,18 @@ var Wunderground = function(apikey) {
 
         // Request the url
         request(url, function (error, response, body) {
+            var json = false;
             if (!error && response.statusCode === 200) {
                 error = false;
                 try {
-                    callback.call(that, error, JSON.parse(body));
+                    json = JSON.parse(body);
                 } catch (err) {
-                    console.log('Exception caught in JSON.parse', body);
-                    throw (err)
+                    console.error('Exception caught in JSON.parse', body);
+                    error = err;
                 }
-                return;
-            } else if (error) {
-                callback.call(that, error, false);
-                return;
             }
-
+            callback.call(that, error, json);
+            return;
         });
     };
 };

--- a/test/testWundergroundnode.js
+++ b/test/testWundergroundnode.js
@@ -162,4 +162,25 @@ describe('Testing Weather Underground Node Client:', function(){
             });
         });
     });
+
+    it('Test a historical call with no day', function(done){
+        getDevKey(function(key){
+            var wunderground = new Wunderground(key);
+            wunderground.history('', '84111', function(err, response){
+                err.should.equal(true);
+                done();
+            });
+        });
+    });
+
+    it('Test a historical call with no query', function(done){
+        getDevKey(function(key){
+            var wunderground = new Wunderground(key);
+            wunderground.history('19800322', '', function(err, response){
+                err.should.equal(true);
+                done();
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
Handle a JSON parse error by sending it as the error in the callback rather than relying on a try/catch (which doesn’t work well with async). This prevents the process from crashing when Weather Underground returns HTML rather than JSON.